### PR TITLE
fix(#4): adapt webhook field types for all webhooks

### DIFF
--- a/internal/api/v1/nexiapi/webhooks.go
+++ b/internal/api/v1/nexiapi/webhooks.go
@@ -21,21 +21,21 @@ const EventPaymentCheckoutCompleted = "payment.checkout.completed"
 type DataPaymentCheckoutCompleted struct {
 	Order struct {
 		Amount struct {
-			Amount   string `json:"amount"`
+			Amount   int32  `json:"amount"`
 			Currency string `json:"currency"`
 		} `json:"amount"`
 		Reference   string `json:"reference"`
 		Description string `json:"description"`
 		OrderItems  []struct {
-			GrossTotalAmount string `json:"grossTotalAmount"`
-			Name             string `json:"name"`
-			NetTotalAmount   string `json:"netTotalAmount"`
-			Quantity         string `json:"quantity"`
-			Reference        string `json:"reference"`
-			TaxRate          string `json:"taxRate"`
-			TaxAmount        string `json:"taxAmount"`
-			Unit             string `json:"unit"`
-			UnitPrice        string `json:"unitPrice"`
+			GrossTotalAmount int32   `json:"grossTotalAmount"`
+			Name             string  `json:"name"`
+			NetTotalAmount   int32   `json:"netTotalAmount"`
+			Quantity         float64 `json:"quantity"`
+			Reference        string  `json:"reference"`
+			TaxRate          int32   `json:"taxRate"`
+			TaxAmount        int32   `json:"taxAmount"`
+			Unit             string  `json:"unit"`
+			UnitPrice        int32   `json:"unitPrice"`
 		} `json:"orderItems"`
 	} `json:"order"`
 	Consumer struct {
@@ -76,22 +76,22 @@ const EventPaymentCancelCreated = "payment.cancel.created"
 type DataPaymentCancelCreated struct {
 	CancelId   string `json:"cancelId"`
 	OrderItems []struct {
-		GrossTotalAmount string `json:"grossTotalAmount"`
-		Name             string `json:"name"`
-		NetTotalAmount   string `json:"netTotalAmount"`
-		Quantity         string `json:"quantity"`
-		Reference        string `json:"reference"`
-		TaxRate          string `json:"taxRate"`
-		TaxAmount        string `json:"taxAmount"`
-		Unit             string `json:"unit"`
-		UnitPrice        string `json:"unitPrice"`
+		GrossTotalAmount int32   `json:"grossTotalAmount"`
+		Name             string  `json:"name"`
+		NetTotalAmount   int32   `json:"netTotalAmount"`
+		Quantity         float64 `json:"quantity"`
+		Reference        string  `json:"reference"`
+		TaxRate          int32   `json:"taxRate"`
+		TaxAmount        int32   `json:"taxAmount"`
+		Unit             string  `json:"unit"`
+		UnitPrice        int32   `json:"unitPrice"`
 	} `json:"orderItems"`
 	MyReference string `json:"myReference"`
 	Amount      struct {
-		Amount   string `json:"amount"`
+		Amount   int32  `json:"amount"`
 		Currency string `json:"currency"`
 	} `json:"amount"`
-	SurchargeAmount string `json:"surchargeAmount"`
+	SurchargeAmount int32  `json:"surchargeAmount"`
 	PaymentId       string `json:"paymentId"`
 }
 
@@ -112,24 +112,24 @@ type DataPaymentChargeCreated struct {
 		YourReference    string `json:"yourReference"`
 	} `json:"invoiceDetails"`
 	OrderItems []struct {
-		GrossTotalAmount string `json:"grossTotalAmount"`
-		Name             string `json:"name"`
-		NetTotalAmount   string `json:"netTotalAmount"`
-		Quantity         string `json:"quantity"`
-		Reference        string `json:"reference"`
-		TaxRate          string `json:"taxRate"`
-		TaxAmount        string `json:"taxAmount"`
-		Unit             string `json:"unit"`
-		UnitPrice        string `json:"unitPrice"`
+		GrossTotalAmount int32   `json:"grossTotalAmount"`
+		Name             string  `json:"name"`
+		NetTotalAmount   int32   `json:"netTotalAmount"`
+		Quantity         float64 `json:"quantity"`
+		Reference        string  `json:"reference"`
+		TaxRate          int32   `json:"taxRate"`
+		TaxAmount        int32   `json:"taxAmount"`
+		Unit             string  `json:"unit"`
+		UnitPrice        int32   `json:"unitPrice"`
 	} `json:"orderItems"`
 	ReservationId           string `json:"reservationId"`
 	ReconciliationReference string `json:"reconciliationReference"`
 	MyReference             string `json:"myReference"`
 	Amount                  struct {
-		Amount   string `json:"amount"`
+		Amount   int32  `json:"amount"`
 		Currency string `json:"currency"`
 	} `json:"amount"`
-	SurchargeAmount string `json:"surchargeAmount"`
+	SurchargeAmount int32  `json:"surchargeAmount"`
 	PaymentId       string `json:"paymentId"`
 }
 
@@ -186,24 +186,24 @@ type DataPaymentChargeFailed struct {
 		YourReference    string `json:"yourReference"`
 	} `json:"invoiceDetails"`
 	OrderItems []struct {
-		GrossTotalAmount string `json:"grossTotalAmount"`
-		Name             string `json:"name"`
-		NetTotalAmount   string `json:"netTotalAmount"`
-		Quantity         string `json:"quantity"`
-		Reference        string `json:"reference"`
-		TaxRate          string `json:"taxRate"`
-		TaxAmount        string `json:"taxAmount"`
-		Unit             string `json:"unit"`
-		UnitPrice        string `json:"unitPrice"`
+		GrossTotalAmount int32   `json:"grossTotalAmount"`
+		Name             string  `json:"name"`
+		NetTotalAmount   int32   `json:"netTotalAmount"`
+		Quantity         float64 `json:"quantity"`
+		Reference        string  `json:"reference"`
+		TaxRate          int32   `json:"taxRate"`
+		TaxAmount        int32   `json:"taxAmount"`
+		Unit             string  `json:"unit"`
+		UnitPrice        int32   `json:"unitPrice"`
 	} `json:"orderItems"`
 	ReservationId           string `json:"reservationId"`
 	ReconciliationReference string `json:"reconciliationReference"`
 	MyReference             string `json:"myReference"`
 	Amount                  struct {
-		Amount   string `json:"amount"`
+		Amount   int32  `json:"amount"`
 		Currency string `json:"currency"`
 	} `json:"amount"`
-	SurchargeAmount string `json:"surchargeAmount"`
+	SurchargeAmount int32  `json:"surchargeAmount"`
 	PaymentId       string `json:"paymentId"`
 }
 
@@ -220,15 +220,15 @@ type DataPaymentChargeFailedV2 struct {
 	} `json:"error"`
 	ChargeId   string `json:"chargeId"`
 	OrderItems []struct {
-		GrossTotalAmount string `json:"grossTotalAmount"`
-		Name             string `json:"name"`
-		NetTotalAmount   string `json:"netTotalAmount"`
-		Quantity         string `json:"quantity"`
-		Reference        string `json:"reference"`
-		TaxRate          string `json:"taxRate"`
-		TaxAmount        string `json:"taxAmount"`
-		Unit             string `json:"unit"`
-		UnitPrice        string `json:"unitPrice"`
+		GrossTotalAmount int32   `json:"grossTotalAmount"`
+		Name             string  `json:"name"`
+		NetTotalAmount   int32   `json:"netTotalAmount"`
+		Quantity         float64 `json:"quantity"`
+		Reference        string  `json:"reference"`
+		TaxRate          int32   `json:"taxRate"`
+		TaxAmount        int32   `json:"taxAmount"`
+		Unit             string  `json:"unit"`
+		UnitPrice        int32   `json:"unitPrice"`
 	} `json:"orderItems"`
 	PaymentMethod           string `json:"paymentMethod"`
 	PaymentType             string `json:"paymentType"`
@@ -236,10 +236,10 @@ type DataPaymentChargeFailedV2 struct {
 	ReconciliationReference string `json:"reconciliationReference"`
 	MyReference             string `json:"myReference"`
 	Amount                  struct {
-		Amount   string `json:"amount"`
+		Amount   int32  `json:"amount"`
 		Currency string `json:"currency"`
 	} `json:"amount"`
-	SurchargeAmount string `json:"surchargeAmount"`
+	SurchargeAmount int32  `json:"surchargeAmount"`
 	PaymentId       string `json:"paymentId"`
 }
 


### PR DESCRIPTION
the webhook examples in the API docs are wrong, field types are the same as API request fields instead of strings.